### PR TITLE
Fix node_exporter scraping and Loki URL

### DIFF
--- a/super-script
+++ b/super-script
@@ -58,7 +58,7 @@ fi
 # ------------------------------------------------------------
 say "Updating packages…"
 $SUDO apt-get update -y
-$SUDO apt-get install -y \
+$SUDO apt-get install -y --no-install-recommends \
   ca-certificates gnupg lsb-release curl git unzip tar make jq \
   ufw fail2ban python3 python3-pip nmap
 
@@ -224,7 +224,7 @@ grafana_admin_password: "changeme"  # change post-install or set here
 
 # Prometheus targets (expand as you onboard servers)
 prom_targets:
-  - "localhost:9100"            # node_exporter on this box
+  # Add more targets like "10.0.0.12:9100", "web-1:9100" etc. The local host is auto-added.
   - "localhost:9090"            # scrape prometheus itself
 YAML
 
@@ -241,7 +241,7 @@ scrape_configs:
       - targets: ['localhost:9090']
   - job_name: 'nodes'
     static_configs:
-      - targets: {{ prom_targets | to_json }}
+      - targets: {{ ((prom_targets | default([])) + [ansible_default_ipv4.address ~ ':9100']) | unique | to_json }}
 J2
 
 # Alertmanager (Slack optional)
@@ -269,7 +269,7 @@ cat > templates/promtail-config.yml.j2 <<'J2'
 server:
   http_listen_port: 9080
 clients:
-  - url: "http://{{ ansible_default_ipv4.address }}:3100/loki/api/v1/push"
+  - url: "http://loki:3100/loki/api/v1/push"
 positions:
   filename: /var/lib/promtail/positions.yaml
 scrape_configs:


### PR DESCRIPTION
## Summary
- ensure Prometheus scrapes the host's node_exporter by default
- use Loki service name for promtail
- slim base install by avoiding recommended packages

## Testing
- `bash -n super-script`


------
https://chatgpt.com/codex/tasks/task_e_68ba7fca0cb48331ac36b8adeb92d639